### PR TITLE
Age annotation: "eighteen" -> "thirteen"

### DIFF
--- a/views/legal.jade
+++ b/views/legal.jade
@@ -68,7 +68,7 @@ body.legal
       h2
         | 3. Use of the Services
       h3
-        | Eligibility: “You have to be eighteen or older.”
+        | Eligibility: “You have to be thirteen or older.”
       p
         | No individual under the age of thirteen (13) may use the Services or provide any information to Fog Creek or otherwise through the Services (including, for example, a name, address, telephone number, or email address). If you are a parent and believe your child under the age of thirteen (13) has created an Account or otherwise provided personal information to Fog Creek, please contact us at customer-service@fogcreek.com. In addition, you may only use the Services to the extent not legally prohibited from doing so.
 


### PR DESCRIPTION
Change ToS eligibility annotation from "eighteen" to "thirteen" to match ToS eligibility text, which says "thirteen (13)" (assuming the ToS text is the correct one)